### PR TITLE
feat: Align Kotlin JSON5 lexer with specification

### DIFF
--- a/lib/src/main/kotlin/io/github/json5/kotlin/JSON5Lexer.kt
+++ b/lib/src/main/kotlin/io/github/json5/kotlin/JSON5Lexer.kt
@@ -36,9 +36,21 @@ class JSON5Lexer(private val source: String) {
             'n' -> readNull()
             't' -> readTrue()
             'f' -> readFalse()
-            'I' -> readInfinity()
-            'N' -> readNaN()
-            '+', '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.' -> readNumber()
+            'I' -> readInfinity() // Handles "Infinity"
+            'N' -> readNaN()     // Handles "NaN"
+            // Handle numbers, including those starting with a sign
+            '+', '-' -> {
+                // Peek ahead for Infinity or NaN
+                val peekedChar = peek()
+                if (peekedChar == 'I') {
+                    readSignedInfinity()
+                } else if (peekedChar == 'N') {
+                    readSignedNaN()
+                } else {
+                    readNumber()
+                }
+            }
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.' -> readNumber()
             else -> {
                 if (isIdentifierStart(currentChar)) {
                     readIdentifier()
@@ -51,12 +63,33 @@ class JSON5Lexer(private val source: String) {
 
     private fun isIdentifierStart(c: Char?): Boolean {
         if (c == null) return false
-        return c == '$' || c == '_' || c.isLetter()
+        if (c == '$' || c == '_') return true // $ and _ are explicit
+        return when (c.category) {
+            CharCategory.UPPERCASE_LETTER,          // Lu
+            CharCategory.LOWERCASE_LETTER,          // Ll
+            CharCategory.TITLECASE_LETTER,          // Lt
+            CharCategory.MODIFIER_LETTER,           // Lm
+            CharCategory.OTHER_LETTER,              // Lo
+            CharCategory.LETTER_NUMBER              // Nl
+            -> true
+            else -> false
+        }
     }
 
     private fun isIdentifierPart(c: Char?): Boolean {
         if (c == null) return false
-        return c == '$' || c == '_' || c.isLetterOrDigit() || c == '\u200C' || c == '\u200D'
+        // Check against IdentifierStart first (includes $, _)
+        if (isIdentifierStart(c)) return true
+        return when (c.category) {
+            CharCategory.NON_SPACING_MARK,          // Mn
+            CharCategory.COMBINING_SPACING_MARK,    // Mc
+            CharCategory.DECIMAL_DIGIT_NUMBER,      // Nd
+            CharCategory.CONNECTOR_PUNCTUATION     // Pc (includes _ but already covered by isIdentifierStart)
+            -> true
+            // Explicitly check for ZWNJ and ZWJ if not covered by categories above
+            // (though they are Cf - Format characters, might need specific handling if not part of a category)
+            else -> c == '\u200C' || c == '\u200D' // ZWNJ (U+200C) or ZWJ (U+200D)
+        }
     }
 
     private fun advance() {
@@ -80,7 +113,7 @@ class JSON5Lexer(private val source: String) {
     }
 
     private fun skipWhitespace() {
-        while (currentChar != null && currentChar!!.isWhitespace()) {
+        while (currentChar != null && (currentChar!!.isWhitespace() || currentChar == '\uFEFF')) {
             advance()
         }
     }
@@ -129,9 +162,27 @@ class JSON5Lexer(private val source: String) {
                 }
                 '\\' -> {
                     advance() // Skip the backslash
-                    buffer.append(readEscapeSequence())
+                    val escapedChar = readEscapeSequence()
+                    if (escapedChar != null) {
+                        buffer.append(escapedChar)
+                    }
                 }
-                '\n', '\r' -> throw JSON5Exception("Unterminated string", line, startColumn)
+                // Handle unescaped line terminators
+                '\n', '\r' -> throw JSON5Exception(
+                    "Unterminated string literal; unescaped LF or CR found at line $line, column $column. Use line continuations (\\\\n or \\\\r) or escape them (\\n, \\r).",
+                    line,
+                    column // Use current column for more accuracy
+                )
+                '\u2028' -> { // Line Separator
+                    System.err.println("Warning: JSON5: Unescaped U+2028 (Line Separator) in string at line $line, column $column. Consider escaping it as \\u2028.")
+                    buffer.append(currentChar)
+                    advance()
+                }
+                '\u2029' -> { // Paragraph Separator
+                    System.err.println("Warning: JSON5: Unescaped U+2029 (Paragraph Separator) in string at line $line, column $column. Consider escaping it as \\u2029.")
+                    buffer.append(currentChar)
+                    advance()
+                }
                 else -> {
                     buffer.append(currentChar)
                     advance()
@@ -146,24 +197,41 @@ class JSON5Lexer(private val source: String) {
         return Token.StringToken(buffer.toString(), line, startColumn)
     }
 
-    private fun readEscapeSequence(): Char {
-        return when (currentChar) {
+    private fun readEscapeSequence(): Char? { // Return type changed to Char?
+        return when (val c = currentChar) {
+            // Line Terminators for Line Continuations
+            '\n' -> { // LF
+                advance()
+                null // Indicates line continuation
+            }
+            '\r' -> { // CR
+                advance()
+                if (currentChar == '\n') { // CR+LF
+                    advance()
+                }
+                null // Indicates line continuation
+            }
+            '\u2028' -> { // Line Separator
+                advance()
+                null // Indicates line continuation
+            }
+            '\u2029' -> { // Paragraph Separator
+                advance()
+                null // Indicates line continuation
+            }
+
+            // Standard Escape Sequences
             'b' -> { advance(); '\b' }
-            'f' -> { advance(); '\u000C' }
-            'n' -> { advance(); '\n' }
-            'r' -> { advance(); '\r' }
+            'f' -> { advance(); '\u000C' } // Form Feed
+            'n' -> { advance(); '\n' } // Line Feed (actual character, not continuation)
+            'r' -> { advance(); '\r' } // Carriage Return (actual character, not continuation)
             't' -> { advance(); '\t' }
-            'v' -> { advance(); '\u000B' }
-            '0' -> { advance(); '\u0000' }
+            'v' -> { advance(); '\u000B' } // Vertical Tab
+            '0' -> { advance(); '\u0000' } // Null character (only if not followed by a digit)
             '\\' -> { advance(); '\\' }
             '\'' -> { advance(); '\'' }
             '"' -> { advance(); '"' }
-            '\n' -> { advance(); '\n' }
-            '\r' -> {
-                advance()
-                if (currentChar == '\n') advance()
-                ' ' // Line continuation returns nothing
-            }
+            // Hexadecimal and Unicode escapes are handled below
             'x' -> {
                 advance()
                 readHexEscape(2)
@@ -173,9 +241,16 @@ class JSON5Lexer(private val source: String) {
                 readHexEscape(4)
             }
             else -> {
-                val c = currentChar
+                // Check if it's one of the line terminators that might be valid if not for line continuation
+                // This part is tricky. If we are here, it means it's not `\n`, `\r`, `\u2028`, `\u2029`
+                // (as those are handled above for line continuations if they were the char after `\`)
+                // or any other valid escape.
+                // So, if `c` (currentChar) is a line terminator here, it's an invalid escape.
+                // However, the JSON5 spec says "any other character" is the character itself.
+                // This implies that `\` followed by a character not in the escape set is just that character.
+                // Example: `\q` would be `q`.
                 advance()
-                c ?: throw JSON5Exception("Invalid escape sequence", line, column)
+                c // Return the character itself
             }
         }
     }
@@ -240,12 +315,13 @@ class JSON5Lexer(private val source: String) {
         val startLine = line
 
         // Verify that the characters spell "Infinity"
+        // This is called when 'I' is encountered without a preceding sign.
         if (source.substring(pos, minOf(pos + 8, source.length)) == "Infinity") {
             repeat(8) { advance() }
             return Token.NumericToken(Double.POSITIVE_INFINITY, startLine, startColumn)
         }
 
-        throw JSON5Exception("Unexpected identifier", startLine, startColumn)
+        throw JSON5Exception("Unexpected identifier starting with I", startLine, startColumn)
     }
 
     private fun readNaN(): Token {
@@ -253,31 +329,204 @@ class JSON5Lexer(private val source: String) {
         val startLine = line
 
         // Verify that the characters spell "NaN"
+        // This is called when 'N' is encountered without a preceding sign.
         if (source.substring(pos, minOf(pos + 3, source.length)) == "NaN") {
             repeat(3) { advance() }
             return Token.NumericToken(Double.NaN, startLine, startColumn)
         }
 
-        throw JSON5Exception("Unexpected identifier", startLine, startColumn)
+        throw JSON5Exception("Unexpected identifier starting with N", startLine, startColumn)
+    }
+
+    private fun readSignedInfinity(): Token {
+        val startColumn = column
+        val startLine = line
+        val sign = currentChar
+        advance() // Consume sign
+
+        if (source.substring(pos, minOf(pos + 8, source.length)) == "Infinity") {
+            repeat(8) { advance() }
+            return if (sign == '-') {
+                Token.NumericToken(Double.NEGATIVE_INFINITY, startLine, startColumn)
+            } else {
+                Token.NumericToken(Double.POSITIVE_INFINITY, startLine, startColumn)
+            }
+        }
+        // This case should ideally not be reached if peek() in nextToken() is correct
+        throw JSON5Exception("Expected Infinity after sign", startLine, startColumn)
+    }
+
+    private fun readSignedNaN(): Token {
+        val startColumn = column
+        val startLine = line
+        val sign = currentChar
+        advance() // Consume sign
+
+        if (source.substring(pos, minOf(pos + 3, source.length)) == "NaN") {
+            repeat(3) { advance() }
+            // Sign before NaN is ignored as per JSON5 spec and Double.NaN representation
+            return Token.NumericToken(Double.NaN, startLine, startColumn)
+        }
+        // This case should ideally not be reached if peek() in nextToken() is correct
+        throw JSON5Exception("Expected NaN after sign", startLine, startColumn)
     }
 
     private fun readNumber(): Token.NumericToken {
         val startColumn = column
         val startLine = line
         val buffer = StringBuilder()
-        var isNegative = false
 
-        // Handle sign
-        if (currentChar == '+') {
-            advance() // Skip '+'
-        } else if (currentChar == '-') {
-            isNegative = true
-            buffer.append('-')
-            advance() // Skip '-'
+        // Sign is handled by nextToken for Infinity/NaN, or prepended here for other numbers
+        if (currentChar == '+' || currentChar == '-') {
+            buffer.append(currentChar)
+            advance()
         }
 
         // Handle hexadecimal notation
-        if (currentChar == '0' && (peek() == 'x' || peek() == 'X')) {
+        // Check if buffer already contains sign for hex number
+        val hexPrefixPos = if (buffer.isNotEmpty() && (buffer[0] == '+' || buffer[0] == '-')) 1 else 0
+        if (source.substring(pos).startsWith("0x", ignoreCase = true) ||
+            (buffer.length > hexPrefixPos && buffer.substring(hexPrefixPos) == "0" && (peek() == 'x' || peek() == 'X'))) {
+            if (buffer.isEmpty() || (buffer.length == 1 && (buffer[0] == '+' || buffer[0] == '-'))) {
+                 buffer.append('0')
+                 advance() // Skip '0'
+            } else if (buffer.isNotEmpty() && buffer.last() != '0') {
+                 // This case means something like "-1" then "0x", which is not a hex.
+                 // Let it proceed to decimal parsing.
+            }
+
+            if (currentChar == 'x' || currentChar == 'X') {
+                 buffer.append(currentChar)
+                 advance() // Skip 'x' or 'X'
+            }
+
+
+            // Read hex digits
+            var hasDigits = false
+            while (currentChar != null && currentChar!!.isHexDigit()) {
+                buffer.append(currentChar)
+                hasDigits = true
+                advance()
+            }
+
+            if (!hasDigits) {
+                throw JSON5Exception("Invalid hexadecimal number: missing digits after 0x", line, column)
+            }
+            // Make sure to handle signed hex if needed, though JSON5 spec implies hex is unsigned.
+            // For now, assuming toDouble handles "0x...", "-0x..." might be an issue if not careful.
+            // Standard libraries usually parse "0x..." as positive. Sign should be outside.
+            // Example: "-0x10" -> -16.0. `buffer.toString().toDouble()` might not work for "-0x10".
+            // Let's refine this.
+            val numericPart = if (buffer.startsWith("-0x") || buffer.startsWith("+0x")) {
+                buffer.substring(0,1) + buffer.substring(3) // -Value or +Value
+            } else if (buffer.startsWith("0x")) {
+                buffer.substring(2)
+            } else { // Should be "0x..."
+                buffer.toString() // Fallback, though likely an error if not "0x..."
+            }
+
+            val doubleValue = numericPart.toLong(16).toDouble()
+            val finalValue = if (buffer.startsWith("-")) -doubleValue else doubleValue
+
+            return Token.NumericToken(finalValue, startLine, startColumn)
+        }
+
+        // Handle decimal notation
+        val originalBufferState = buffer.toString() // Save state in case it's just a '.'
+
+        // Integer part (optional if there's a decimal point)
+        var hasIntegerPart = false
+        if (currentChar?.isDigit() == true) {
+            hasIntegerPart = true
+            while (currentChar != null && currentChar!!.isDigit()) {
+                buffer.append(currentChar)
+                advance()
+            }
+        } else if (currentChar == '.' && (buffer.isEmpty() || buffer.toString() == "+" || buffer.toString() == "-")) {
+            // Handles cases like ".5", "+.5", "-.5"
+            // No digits before '.', so append '0' to ensure it's a valid double string like "0.5"
+            if (buffer.isEmpty()) buffer.append('0')
+            else if (buffer.toString() == "+") buffer.replace(0,1,"0")
+            else if (buffer.toString() == "-") buffer.replace(0,1,"-0")
+            // else if already has digits, this won't be hit
+        }
+
+
+        // Decimal point and fraction part
+        var hasFractionPart = false
+        if (currentChar == '.') {
+            // Avoid adding multiple decimal points if one was prepended for ".5" like cases
+            if (buffer.indexOf('.') == -1) {
+                buffer.append('.')
+            }
+            advance()
+
+            var hasDigitsAfterDecimal = false
+            while (currentChar != null && currentChar!!.isDigit()) {
+                buffer.append(currentChar)
+                hasDigitsAfterDecimal = true
+                advance()
+            }
+            // A number cannot end with just a decimal point e.g. "1." or simply "."
+            if (!hasDigitsAfterDecimal && !hasIntegerPart && buffer.endsWith("0.")) { // for cases like ".xyz" -> "0.xyz"
+                 // if it was just "." or "+." or "-."
+                 if (originalBufferState == "." || originalBufferState == "+." || originalBufferState == "-." ){
+                    throw JSON5Exception("Invalid number: lone decimal point", line, column)
+                 }
+            } else if (!hasDigitsAfterDecimal && !hasIntegerPart && buffer.toString().endsWith(".")) {
+                 throw JSON5Exception("Invalid number: lone decimal point", line, column)
+            } else if (!hasDigitsAfterDecimal && hasIntegerPart) {
+                // "1." is valid in JSON5, it means 1.0
+            } else if (!hasDigitsAfterDecimal && !hasIntegerPart) { // e.g. "."
+                 throw JSON5Exception("Invalid number: expected digits after decimal point", line, column)
+            }
+            hasFractionPart = true // even if no digits follow, like "1."
+        }
+
+
+        // Exponent part
+        var hasExponentPart = false
+        if (currentChar == 'e' || currentChar == 'E') {
+            buffer.append(currentChar)
+            advance()
+
+            if (currentChar == '+' || currentChar == '-') {
+                buffer.append(currentChar)
+                advance()
+            }
+
+            var hasExponentDigits = false
+            while (currentChar != null && currentChar!!.isDigit()) {
+                buffer.append(currentChar)
+                hasExponentDigits = true
+                advance()
+            }
+
+            if (!hasExponentDigits) {
+                throw JSON5Exception("Invalid exponent in number: missing digits", line, column)
+            }
+
+            hasExponentPart = true
+        }
+
+        val finalString = buffer.toString()
+        // Must have at least one part (integer, fraction, or starts with a decimal point)
+        if (finalString.isEmpty() || finalString == "+" || finalString == "-") {
+             throw JSON5Exception("Invalid number: empty number", line, column)
+        }
+        // handles cases like "." , "+." or "-." that were not caught earlier
+        if ((finalString == "." || finalString == "+." || finalString == "-.") && !hasFractionPart && !hasIntegerPart && !hasExponentPart) {
+            throw JSON5Exception("Invalid number: lone decimal point", line, column)
+        }
+
+
+        val value = try {
+            finalString.toDouble()
+        } catch (e: NumberFormatException) {
+            throw JSON5Exception("Invalid number format: $finalString", line, column, e)
+        }
+        return Token.NumericToken(value, startLine, startColumn)
+    }
             buffer.append('0')
             advance() // Skip '0'
             buffer.append(currentChar)

--- a/lib/src/test/kotlin/io/github/json5/kotlin/JSON5ParseTest.kt
+++ b/lib/src/test/kotlin/io/github/json5/kotlin/JSON5ParseTest.kt
@@ -50,4 +50,137 @@ class JSON5ParseTest {
         }
         exception.lineNumber shouldBe 1
     }
+
+    @Test
+    fun `should parse Infinity values`() {
+        JSON5.parse("Infinity") shouldBe Double.POSITIVE_INFINITY
+        JSON5.parse("+Infinity") shouldBe Double.POSITIVE_INFINITY
+        JSON5.parse("-Infinity") shouldBe Double.NEGATIVE_INFINITY
+    }
+
+    @Test
+    fun `should parse NaN values`() {
+        JSON5.parse("NaN") shouldBe Double.NaN
+        JSON5.parse("+NaN") shouldBe Double.NaN
+        JSON5.parse("-NaN") shouldBe Double.NaN
+    }
+
+    @Test
+    fun `should parse Infinity and NaN values in an array`() {
+        JSON5.parse("[Infinity, -Infinity, NaN, +Infinity, +NaN, -NaN]") shouldBe listOf(
+            Double.POSITIVE_INFINITY,
+            Double.NEGATIVE_INFINITY,
+            Double.NaN,
+            Double.POSITIVE_INFINITY,
+            Double.NaN,
+            Double.NaN
+        )
+    }
+
+    @Test
+    fun `should parse strings with line continuations`() {
+        JSON5.parse(""""abc\\\ndef"""") shouldBe "abcdef"
+        JSON5.parse(""""xy\\\nz"""") shouldBe "xyz"
+        JSON5.parse(""""uvw\\\rx"""") shouldBe "uvwx" // Carriage return
+        JSON5.parse(""""ijk\\\r\nlmn"""") shouldBe "ijklmn" // CRLF
+    }
+
+    @Test
+    fun `should parse strings with multiple line continuations`() {
+        JSON5.parse(""""one\\\ntwo\\\nthree"""") shouldBe "onetwothree"
+        JSON5.parse(""""alpha\\\rbeta\\\rgamma"""") shouldBe "alphabetagamma"
+    }
+
+    @Test
+    fun `should parse strings with mixed line continuations and other escape sequences`() {
+        JSON5.parse(""""error:\\\n\tFile not found"""") shouldBe "error:\tFile not found"
+        JSON5.parse(""""a\\\nb\\tc"""") shouldBe "ab\tc"
+        JSON5.parse(""""first line\\\nsecond line\\\n\bthird line"""") shouldBe "first linesecond line\bthird line"
+    }
+
+    @Test
+    fun `should parse strings with line continuations in object values`() {
+        JSON5.parse("""{"key": "value\\\ncontinuation"}""") shouldBe mapOf("key" to "valuecontinuation")
+    }
+
+    @Test
+    fun `should parse strings with line continuations in array values`() {
+        JSON5.parse("""["element1\\\npart2", "another"]""") shouldBe listOf("element1part2", "another")
+    }
+
+    @Test
+    fun `should parse unquoted keys with Unicode letters`() {
+        JSON5.parse("{π: 3.14}") shouldBe mapOf("π" to 3.14)
+        JSON5.parse("{привет: \"world\"}") shouldBe mapOf("привет" to "world")
+        JSON5.parse("{日本語: \"Japanese\"}") shouldBe mapOf("日本語" to "Japanese")
+        JSON5.parse("{κόσμε: \"Greek\"}") shouldBe mapOf("κόσμε" to "Greek") // Greek
+        JSON5.parse("{नमस्ते: \"Hindi\"}") shouldBe mapOf("नमस्ते" to "Hindi") // Devanagari
+    }
+
+    @Test
+    fun `should parse unquoted keys with Unicode letter numbers (Nl)`() {
+        JSON5.parse("{Ⅰ: 1}") shouldBe mapOf("Ⅰ" to 1.0) // Roman numeral one
+        JSON5.parse("{Ⅱ: 2, Ⅲ: 3}") shouldBe mapOf("Ⅱ" to 2.0, "Ⅲ" to 3.0)
+    }
+
+    @Test
+    fun `should parse unquoted keys with Unicode connector punctuation (Pc)`() {
+        JSON5.parse("{my‿key: \"value\"}") shouldBe mapOf("my‿key" to "value") // U+203F (undertie)
+        JSON5.parse("{other＿key: \"data\"}") shouldBe mapOf("other＿key" to "data") // U+FF3F (fullwidth low line)
+    }
+
+    @Test
+    fun `should parse unquoted keys with Unicode combining marks (Mn, Mc)`() {
+        JSON5.parse("{char̀: \"accented\"}") shouldBe mapOf("char̀" to "accented") // a + combining grave accent
+        JSON5.parse("{öp: \"umlaut\"}") shouldBe mapOf("öp" to "umlaut") // o + combining diaeresis
+        JSON5.parse("{a̱b: \"macron\"}") shouldBe mapOf("a̱b" to "macron") // a + combining macron below
+        // Note: Combining marks cannot be at the start of an identifier.
+    }
+
+    @Test
+    fun `should parse unquoted keys with mixed Unicode characters including dollar and underscore`() {
+        JSON5.parse("{\$myKey_1π: \"value\"}") shouldBe mapOf("\$myKey_1π" to "value")
+        JSON5.parse("{_привет_Ⅱ: \"mixed\"}") shouldBe mapOf("_привет_Ⅱ" to "mixed")
+    }
+
+    @Test
+    fun `should parse strings with unescaped U+2028 Line Separator`() {
+        JSON5.parse(""""Hello\u2028World"""") shouldBe "Hello\u2028World"
+        JSON5.parse("""{"text": "Line one\u2028Line two"}""") shouldBe mapOf("text" to "Line one\u2028Line two")
+        JSON5.parse("""["First part\u2028Second part"]""") shouldBe listOf("First part\u2028Second part")
+    }
+
+    @Test
+    fun `should parse strings with unescaped U+2029 Paragraph Separator`() {
+        JSON5.parse(""""Sentence one.\u2029Sentence two."""") shouldBe "Sentence one.\u2029Sentence two."
+        JSON5.parse("""{"paragraph": "Content one.\u2029Content two."}""") shouldBe mapOf("paragraph" to "Content one.\u2029Content two.")
+        JSON5.parse("""["Para1.\u2029Para2." , "Para3.\u2029Para4." ]""") shouldBe listOf("Para1.\u2029Para2.", "Para3.\u2029Para4.")
+    }
+
+    @Test
+    fun `should parse strings with mixed unescaped U+2028 and U+2029`() {
+        JSON5.parse(""""Line A\u2028Line B\u2029Paragraph C"""") shouldBe "Line A\u2028Line B\u2029Paragraph C"
+    }
+
+    @Test
+    fun `should treat U+FEFF (BOM) as whitespace`() {
+        JSON5.parse("""{\uFEFF"key"\uFEFF:\uFEFF"value"\uFEFF}""") shouldBe mapOf("key" to "value")
+        JSON5.parse("""[\uFEFF1\uFEFF,\uFEFFtrue\uFEFF]""") shouldBe listOf(1.0, true)
+        JSON5.parse("""\uFEFF{\uFEFF"a":\uFEFF1\uFEFF}\uFEFF""") shouldBe mapOf("a" to 1.0)
+        JSON5.parse("""\uFEFF[\uFEFFtrue\uFEFF]\uFEFF""") shouldBe listOf(true)
+    }
+
+    @Test
+    fun `should treat U+00A0 (Non-breaking space) as whitespace`() {
+        JSON5.parse("""{\u00A0"key"\u00A0:\u00A0"value"\u00A0}""") shouldBe mapOf("key" to "value")
+        JSON5.parse("""[\u00A01\u00A0,\u00A0true\u00A0]""") shouldBe listOf(1.0, true)
+        JSON5.parse("""\u00A0{\u00A0"a":\u00A01\u00A0}\u00A0""") shouldBe mapOf("a" to 1.0)
+        JSON5.parse("""\u00A0[\u00A0true\u00A0]\u00A0""") shouldBe listOf(true)
+    }
+
+    @Test
+    fun `should treat mixed JSON5 whitespace characters correctly`() {
+        // Mix of space, tab, LF, CR, BOM, NBSP
+        JSON5.parse("{\t\"key\" \n:\r\n \"value\"\uFEFF,\u00A0\"next\"\t:\rtrue\n}") shouldBe mapOf("key" to "value", "next" to true)
+    }
 }


### PR DESCRIPTION
I've implemented several enhancements and fixes to the JSON5 lexer to align it more closely with the official JSON5 specification:

- Infinity & NaN Parsing: I've added support for parsing signed and unsigned Infinity and NaN values (e.g., +Infinity, -Infinity, NaN).
- String Line Continuations: I've ensured that escaped line breaks (e.g., "\ ") in strings are correctly handled, treating them as zero-length.
- Unicode Identifiers: I've expanded validation for unquoted object keys to support a wider range of Unicode characters as per ECMAScript 5.1 identifier rules (using Unicode character categories).
- U+2028/U+2029 Warnings: I've set it up to issue warnings when unescaped U+2028 (Line Separator) or U+2029 (Paragraph Separator) characters are found in string literals, while still including them in the parsed value.
- Whitespace Handling: I've added U+FEFF (Byte Order Mark) to the set of recognized whitespace characters.

I've also added numerous corresponding unit tests for these features to JSON5ParseTest.kt.

**Critical Note:** Due to persistent issues with the Gradle build environment (missing gradle-wrapper.jar, unable to bootstrap), I could not run and verify these changes and the full test suite. The implementation is based on code review and adherence to the specification but lacks automated test validation.