### PR TITLE
Fix: Update library version in README to 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ repositories {
 }
 
 dependencies {
-    implementation("hossain.dev:json5kt:1.0.0")
+    implementation("hossain.dev:json5kt:1.1.0")
 }
 ```
 


### PR DESCRIPTION
The README.md file previously listed version 1.0.0 in the installation instructions. I updated this to reflect the correct current version, 1.1.0, as defined in the project's gradle.properties file.

I reviewed other details in the README, including feature descriptions, usage examples, and build instructions, and found them to be consistent with the current codebase.